### PR TITLE
version: Fix default build type is empty

### DIFF
--- a/config/version.mk
+++ b/config/version.mk
@@ -2,11 +2,11 @@ CUSTOM_PLATFORM_VERSION := 1.2
 
 BUILD_DATE := $(shell date -u +%Y%m%d)
 BUILD_TIME := $(shell date -u +%H%M)
-CUSTOM_VERSION := PixelProject_$(CUSTOM_BUILD)-$(CUSTOM_BUILD_TYPE)-$(CUSTOM_PLATFORM_VERSION)-$(BUILD_TIME)-$(BUILD_DATE)
-CUSTOM_VERSION_PROP := fourteen
-
 
 CUSTOM_BUILD_TYPE ?= Unofficial
+
+CUSTOM_VERSION := PixelProject_$(CUSTOM_BUILD)-$(CUSTOM_BUILD_TYPE)-$(CUSTOM_PLATFORM_VERSION)-$(BUILD_TIME)-$(BUILD_DATE)
+CUSTOM_VERSION_PROP := fourteen
 
 # Only include Updater for official  build
 ifeq ($(filter-out Official,$(CUSTOM_BUILD_TYPE)),)


### PR DESCRIPTION
* When the build type is not defined

- Before: CUSTOM_VERSION=PixelProject_alioth--1.2-1543-20240923
- After: CUSTOM_VERSION=PixelProject_alioth-Unofficial-1.2-1543-20240923